### PR TITLE
fix_tests_missing_test_fatal

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+
+0.015     2023-11-09 01:45:19-03:00 America/Sao_Paulo
     [Bug Fixes]
     - Fix missing Test::Fatal and indirect prereqs
 0.014     2023-11-06 02:41:17-03:00 America/Sao_Paulo

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 {{$NEXT}}
-
+    [Bug Fixes]
+    - Fix missing Test::Fatal and indirect prereqs
 0.014     2023-11-06 02:41:17-03:00 America/Sao_Paulo
     [Bug Fixes]
     - Fixes for negative numbers encoding/decoding

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,16 +21,18 @@ my %WriteMakefileArgs = (
     "Math::BigInt" => "1.999811",
     "Module::Load" => "0.36",
     "Object::Pad" => "0.805",
-    "Scalar::Util" => "1.63"
+    "Scalar::Util" => "1.63",
+    "indirect" => "0.39"
   },
   "TEST_REQUIRES" => {
     "File::Spec" => 0,
     "IO::Handle" => 0,
     "IPC::Open3" => 0,
     "Test::CheckDeps" => "0.010",
+    "Test::Fatal" => "0.017",
     "Test::More" => "0.94"
   },
-  "VERSION" => "0.014",
+  "VERSION" => "0.015",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -47,7 +49,9 @@ my %FallbackPrereqs = (
   "Object::Pad" => "0.805",
   "Scalar::Util" => "1.63",
   "Test::CheckDeps" => "0.010",
-  "Test::More" => "0.94"
+  "Test::Fatal" => "0.017",
+  "Test::More" => "0.94",
+  "indirect" => "0.39"
 );
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blockchain::Ethereum::ABI - ABI utility for encoding/decoding ethereum contract 
 
 # VERSION
 
-version 0.014
+version 0.015
 
 # SYNOPSIS
 

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires "Math::BigInt" => "1.999811";
 requires "Module::Load" => "0.36";
 requires "Object::Pad" => "0.805";
 requires "Scalar::Util" => "1.63";
+requires "indirect" => "0.39";
 requires "perl" => "v5.26.0";
 
 on 'test' => sub {
@@ -13,6 +14,7 @@ on 'test' => sub {
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
   requires "Test::CheckDeps" => "0.010";
+  requires "Test::Fatal" => "0.017";
   requires "Test::More" => "0.94";
 };
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name                = Blockchain-Ethereum-ABI
-version             = 0.014
+version             = 0.015
 author              = Reginaldo Costa <refeco@cpan.org>
 license             = MIT
 copyright_holder    = REFECO
@@ -14,3 +14,7 @@ Crypt::Digest::Keccak256    = 0.078
 Math::BigInt                = 1.999811
 Scalar::Util                = 1.63
 Module::Load                = 0.36
+indirect                    = 0.39
+
+[Prereqs / TestRequires]
+Test::Fatal                 = 0.017


### PR DESCRIPTION
Fix tests: https://cpants.cpanauthors.org/release/REFECO/Blockchain-Ethereum-ABI-0.014
- Missing Test:Fatal prereq
- Missing indirect prereq